### PR TITLE
from-to date filter

### DIFF
--- a/ImmiBridge/ImmiBridge/UI/ContentView.swift
+++ b/ImmiBridge/ImmiBridge/UI/ContentView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import UniformTypeIdentifiers
 
 struct ContentView: View {
     @EnvironmentObject private var model: PhotoBackupViewModel
@@ -984,7 +985,7 @@ private extension ContentView {
 
         let panel = NSSavePanel()
         panel.nameFieldStringValue = defaultName
-        panel.allowedFileTypes = ["txt"]
+        panel.allowedContentTypes = [.plainText]
         if panel.runModal() == .OK, let url = panel.url {
             do {
                 try text.write(to: url, atomically: true, encoding: .utf8)

--- a/ImmiBridge/ImmiBridge/UI/ContentView.swift
+++ b/ImmiBridge/ImmiBridge/UI/ContentView.swift
@@ -383,11 +383,13 @@ private extension ContentView {
                         HStack(spacing: 8) {
                             DatePicker("From", selection: $model.filterStartDate, displayedComponents: .date)
                                 .labelsHidden()
+                                .accessibilityLabel("From")
                                 .disabled(!model.dateFilterEnabled || model.isRunning)
                                 .frame(maxWidth: 180)
 
                             DatePicker("To", selection: $model.filterEndDate, displayedComponents: .date)
                                 .labelsHidden()
+                                .accessibilityLabel("To")
                                 .disabled(!model.dateFilterEnabled || model.isRunning)
                                 .frame(maxWidth: 180)
                         }

--- a/ImmiBridge/ImmiBridge/UI/ContentView.swift
+++ b/ImmiBridge/ImmiBridge/UI/ContentView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct ContentView: View {
     @EnvironmentObject private var model: PhotoBackupViewModel
@@ -83,9 +84,17 @@ struct ContentView: View {
 
                     HStack(alignment: .top, spacing: 14) {
                         VStack(alignment: .leading, spacing: 8) {
-                            Text("Log")
-                                .font(.system(.headline, design: .rounded))
-                                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                            HStack {
+                                Text("Log")
+                                    .font(.system(.headline, design: .rounded))
+                                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                                Spacer()
+                                Button("Download") {
+                                    saveLogs()
+                                }
+                                .buttonStyle(.bordered)
+                                .disabled(model.logLines.isEmpty)
+                            }
                             LogConsoleView(lines: model.logLines, isActive: isLogDrawerOpen)
                         }
 
@@ -358,6 +367,31 @@ private extension ContentView {
                             .disabled(model.isRunning || !model.photosIsConnected)
                         }
                     }
+                }
+                
+                HStack(spacing: 12) {
+                    Text("Filter:")
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .frame(width: 70, alignment: .leading)
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Toggle("Enable Date Range", isOn: $model.dateFilterEnabled)
+                            .toggleStyle(.switch)
+                            .disabled(model.isRunning)
+
+                        HStack(spacing: 8) {
+                            DatePicker("From", selection: $model.filterStartDate, displayedComponents: .date)
+                                .labelsHidden()
+                                .disabled(!model.dateFilterEnabled || model.isRunning)
+                                .frame(maxWidth: 180)
+
+                            DatePicker("To", selection: $model.filterEndDate, displayedComponents: .date)
+                                .labelsHidden()
+                                .disabled(!model.dateFilterEnabled || model.isRunning)
+                                .frame(maxWidth: 180)
+                        }
+                    }
+                    .font(.system(.subheadline, design: .rounded))
                 }
 
                 HStack(spacing: 12) {
@@ -877,6 +911,14 @@ private extension ContentView {
                             .foregroundStyle(DesignSystem.Colors.textSecondary)
                     }
                     VStack(spacing: 2) {
+                        Text("\(model.replacedCount)")
+                            .font(.system(.title2, design: .rounded).bold())
+                            .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        Text("Replaced")
+                            .font(.system(.caption2, design: .rounded))
+                            .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    }
+                    VStack(spacing: 2) {
                         Button {
                             showErrorsSheet = true
                         } label: {
@@ -893,7 +935,7 @@ private extension ContentView {
                         .help("View errors and failed uploads")
                     }
                 }
-                .frame(width: 200, alignment: .center)
+                .frame(width: 220, alignment: .center)
 
                 HStack(spacing: 10) {
                     Button {
@@ -930,6 +972,24 @@ private extension ContentView {
             if Task.isCancelled { return }
             await MainActor.run {
                 model.maybeAutoTestImmich()
+            }
+        }
+    }
+
+    func saveLogs() {
+        let text = model.logLines.map { $0.text }.joined(separator: "\n")
+        let df = DateFormatter()
+        df.dateFormat = "yyyyMMdd-HHmmss"
+        let defaultName = "immibridge-log-\(df.string(from: Date())).txt"
+
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = defaultName
+        panel.allowedFileTypes = ["txt"]
+        if panel.runModal() == .OK, let url = panel.url {
+            do {
+                try text.write(to: url, atomically: true, encoding: .utf8)
+            } catch {
+                // best-effort: ignore write errors
             }
         }
     }

--- a/ImmiBridge/ImmiBridge/UI/PhotoBackupViewModel.swift
+++ b/ImmiBridge/ImmiBridge/UI/PhotoBackupViewModel.swift
@@ -114,6 +114,10 @@ final class PhotoBackupViewModel: ObservableObject {
     @Published var limit: Int? = nil
     @Published var timeoutSeconds: Double = 300
 
+    @Published var dateFilterEnabled: Bool = false
+    @Published var filterStartDate: Date = Calendar.current.date(byAdding: .year, value: -1, to: Date()) ?? Date()
+    @Published var filterEndDate: Date = Date()
+
     @Published var immichServerURL: String = ""
     @Published var immichApiKey: String = ""
     @Published private(set) var immichDeviceId: String = ""
@@ -145,6 +149,7 @@ final class PhotoBackupViewModel: ObservableObject {
     @Published private(set) var uploadedCount: Int = 0
     @Published private(set) var skippedCount: Int = 0
     @Published private(set) var errorCount: Int = 0
+    @Published private(set) var replacedCount: Int = 0
     @Published private(set) var failedUploadCount: Int = 0
     @Published private(set) var isExportingFailedUploads: Bool = false
     @Published private(set) var immichExistChecked: Int = 0
@@ -172,6 +177,7 @@ final class PhotoBackupViewModel: ObservableObject {
     private var didShowFirstThumbnail: Bool = false
     private var lastThumbnailRequestId: PHImageRequestID?
     private var skippedAssetIds: Set<String> = []  // Track asset-level skips (not file-level)
+    private var replacedAssetIds: Set<String> = [] // Track asset-level replacements to avoid double-counting
     private var countedImmichUploadErrorAssetIds: Set<String> = []
     private var currentFailedUploadsDir: URL? = nil
     private var logBuffer: [LogLine] = []
@@ -240,6 +246,15 @@ final class PhotoBackupViewModel: ObservableObject {
         }
         includeAdjustmentData = defaults.object(forKey: "includeAdjustmentData") as? Bool ?? true
         includeHiddenPhotos = defaults.object(forKey: "includeHiddenPhotos") as? Bool ?? false
+
+        // Date range filter persistence
+        dateFilterEnabled = defaults.bool(forKey: "dateFilterEnabled")
+        if let sd = defaults.object(forKey: "filterStartDate") as? Date {
+            filterStartDate = sd
+        }
+        if let ed = defaults.object(forKey: "filterEndDate") as? Date {
+            filterEndDate = ed
+        }
 
         if let arr = defaults.array(forKey: "customFolderBookmarks") as? [Data] {
             customFolderBookmarks = arr
@@ -530,11 +545,13 @@ final class PhotoBackupViewModel: ObservableObject {
             uploadedCount = session.stats.uploadedCount
             skippedCount = session.stats.skippedCount
             errorCount = session.stats.errorCount
+            replacedCount = session.stats.replacedCount
             skippedAssetIds = session.processedAssetIds  // Don't re-count assets from previous session
         } else {
             uploadedCount = 0
             skippedCount = 0
             errorCount = 0
+            replacedCount = 0
             skippedAssetIds = []
         }
         immichExistChecked = 0
@@ -563,6 +580,10 @@ final class PhotoBackupViewModel: ObservableObject {
         defaults.set(Array(selectedAlbumIds), forKey: "selectedAlbumIds")
         defaults.set(immichSyncAlbums, forKey: "immichSyncAlbums")
         defaults.set(immichUpdateChangedAssets, forKey: "immichUpdateChangedAssets")
+        // Persist date filter settings
+        defaults.set(dateFilterEnabled, forKey: "dateFilterEnabled")
+        defaults.set(filterStartDate, forKey: "filterStartDate")
+        defaults.set(filterEndDate, forKey: "filterEndDate")
         keychain.set(immichApiKey, account: "immichApiKey")
 
         let sortOrder: PhotoBackupOptions.SortOrder = (order == .oldest) ? .oldestFirst : .newestFirst
@@ -652,7 +673,8 @@ final class PhotoBackupViewModel: ObservableObject {
             sortOrder: sortOrder,
             limit: limit,
             dryRun: dryRun,
-            since: nil,
+            since: dateFilterEnabled ? Calendar.current.startOfDay(for: filterStartDate) : nil,
+            until: dateFilterEnabled ? Calendar.current.date(byAdding: .day, value: 1, to: Calendar.current.startOfDay(for: filterEndDate)) : nil,
             albumScope: albumScope,
             libraryScope: libraryScope.coreValue,
             includeAdjustmentData: includeAdjustmentData,
@@ -789,6 +811,9 @@ final class PhotoBackupViewModel: ObservableObject {
                             )
                             Task { @MainActor in
                                 weakSelf?.appendLog("Immich Files: uploaded \(r.uploadedFiles), skipped \(r.skippedExisting), replaced \(r.replacedFiles), errors \(r.errorCount)")
+                                if r.replacedFiles > 0 {
+                                    weakSelf?.replacedCount += r.replacedFiles
+                                }
                             }
                         }
                     }
@@ -809,6 +834,7 @@ final class PhotoBackupViewModel: ObservableObject {
                         // Note: these counts are "upload items" (still/video/edited), not Photos asset count.
                         self.uploadedCount = max(0, plan.immichPlannedUploads - plan.immichWouldSkipExisting - plan.immichWouldReplaceExisting)
                         self.skippedCount = plan.immichWouldSkipExisting
+                        self.replacedCount = plan.immichWouldReplaceExisting
                         self.statusText = "Dry run (device id): would upload \(self.uploadedCount), skip \(plan.immichWouldSkipExisting), replace \(plan.immichWouldReplaceExisting) (\(plan.assetsScanned) assets scanned)"
                         self.appendLog("Dry run complete: planned \(plan.immichPlannedUploads) uploads — would upload \(self.uploadedCount), skip \(plan.immichWouldSkipExisting), replace \(plan.immichWouldReplaceExisting)")
                         if !plan.notes.isEmpty {
@@ -835,7 +861,8 @@ final class PhotoBackupViewModel: ObservableObject {
                         updatedSession.stats = BackupSessionStats(
                             uploadedCount: self.uploadedCount,
                             skippedCount: self.skippedCount,
-                            errorCount: self.errorCount
+                            errorCount: self.errorCount,
+                            replacedCount: self.replacedCount
                         )
                         self.saveSessionState(updatedSession)
                         self.checkForResumableSession()
@@ -1191,6 +1218,16 @@ final class PhotoBackupViewModel: ObservableObject {
                         skippedCount += 1
                     }
                 }
+            } else if msg.contains("replacing existing asset") || msg.contains("Immich: replacing existing asset") {
+                // Count replacements
+                if let baseAssetId = extractBaseAssetId(from: msg) {
+                    if !replacedAssetIds.contains(baseAssetId) {
+                        replacedAssetIds.insert(baseAssetId)
+                        replacedCount += 1
+                    }
+                } else {
+                    replacedCount += 1
+                }
             }
 
             if msg.hasPrefix("Immich: recorded failed upload") {
@@ -1387,6 +1424,7 @@ final class PhotoBackupViewModel: ObservableObject {
                 limit: nil,
                 dryRun: false,
                 since: nil,
+                until: nil,
                 albumScope: .allPhotos,
                 libraryScope: .personalAndShared,
                 includeAdjustmentData: includeAdjustments,
@@ -1485,6 +1523,7 @@ final class PhotoBackupViewModel: ObservableObject {
         uploadedCount = 0
         skippedCount = 0
         errorCount = 0
+        replacedCount = 0
         failedUploadCount = 0
         countedImmichUploadErrorAssetIds = []
         immichExistChecked = 0

--- a/ImmiBridge/ImmiBridge/UI/PhotoBackupViewModel.swift
+++ b/ImmiBridge/ImmiBridge/UI/PhotoBackupViewModel.swift
@@ -687,7 +687,7 @@ final class PhotoBackupViewModel: ObservableObject {
             limit: limit,
             dryRun: dryRun,
             since: dateFilterEnabled ? Calendar.current.startOfDay(for: filterStartDate) : nil,
-            until: dateFilterEnabled ? Calendar.current.date(byAdding: .day, value: 1, to: Calendar.current.startOfDay(for: filterEndDate)) : nil,
+            until: dateFilterEnabled ? Calendar.current.date(byAdding: DateComponents(day: 1, second: -1), to: Calendar.current.startOfDay(for: filterEndDate)) : nil,
             albumScope: albumScope,
             libraryScope: libraryScope.coreValue,
             includeAdjustmentData: includeAdjustmentData,

--- a/ImmiBridge/ImmiBridge/UI/PhotoBackupViewModel.swift
+++ b/ImmiBridge/ImmiBridge/UI/PhotoBackupViewModel.swift
@@ -255,6 +255,8 @@ final class PhotoBackupViewModel: ObservableObject {
         if let ed = defaults.object(forKey: "filterEndDate") as? Date {
             filterEndDate = ed
         }
+        // Ensure start <= end after loading persisted values
+        ensureDateOrder()
 
         if let arr = defaults.array(forKey: "customFolderBookmarks") as? [Data] {
             customFolderBookmarks = arr
@@ -284,6 +286,15 @@ final class PhotoBackupViewModel: ObservableObject {
     func completeSetupWizard() {
         defaults.set(true, forKey: "hasCompletedSetupWizard")
         shouldShowSetupWizard = false
+    }
+
+    // Ensure start date is not after end date; swap if necessary
+    private func ensureDateOrder() {
+        if filterStartDate > filterEndDate {
+            let tmp = filterStartDate
+            filterStartDate = filterEndDate
+            filterEndDate = tmp
+        }
     }
 
     func refreshPhotosAuthorizationStatus(autoRequest: Bool = false) {
@@ -581,6 +592,8 @@ final class PhotoBackupViewModel: ObservableObject {
         defaults.set(immichSyncAlbums, forKey: "immichSyncAlbums")
         defaults.set(immichUpdateChangedAssets, forKey: "immichUpdateChangedAssets")
         // Persist date filter settings
+        // Ensure start <= end before persisting/using the values
+        ensureDateOrder()
         defaults.set(dateFilterEnabled, forKey: "dateFilterEnabled")
         defaults.set(filterStartDate, forKey: "filterStartDate")
         defaults.set(filterEndDate, forKey: "filterEndDate")


### PR DESCRIPTION
* from-to filter
<img width="498" height="109" alt="image" src="https://github.com/user-attachments/assets/b3872a83-f268-4d90-8b16-ded3472a7585" />

* download logs as file. In Dry-run also logging the filename and action (upload / skip etc)
<img width="802" height="79" alt="image" src="https://github.com/user-attachments/assets/4cd48a10-12b2-4fec-a1d5-dc48b3be7464" />

* counter for replaced items
<img width="380" height="103" alt="image" src="https://github.com/user-attachments/assets/11434ec2-1506-483e-9e7b-ea278db29352" />


