### PR TITLE
Trigger the Local Network prompt, and fix menu-bar agent mode

### DIFF
--- a/ImmiBridge/ImmiBridge/UI/AppDelegate.swift
+++ b/ImmiBridge/ImmiBridge/UI/AppDelegate.swift
@@ -12,6 +12,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem?
     private let statusMenu = NSMenu()
 
+    /// Strongly retained so "Open Main Window" still works after the window is closed.
+    /// SwiftUI releases WindowGroup windows on close by default, which is why reopening
+    /// used to fall through to building a brand new window.
+    private var mainWindow: NSWindow?
+
+    /// Menu-bar agent mode: keep running with no Dock icon.
+    ///
+    /// Defaults to **false**. Defaulting to true would make the Dock icon vanish for
+    /// everyone on upgrade, which is a surprising thing for an update to do to you.
+    static var hideDockIcon: Bool {
+        get { UserDefaults.standard.bool(forKey: "hideDockIcon") }
+        set {
+            UserDefaults.standard.set(newValue, forKey: "hideDockIcon")
+            NotificationCenter.default.post(name: .hideDockIconPreferenceChanged, object: nil)
+        }
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Request notification permissions
         NotificationManager.shared.requestAuthorization()
@@ -32,7 +49,72 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             object: nil
         )
 
+        // Track which window is the real main window so we can re-show that instance
+        // rather than constructing a replacement.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowDidBecomeKey),
+            name: NSWindow.didBecomeKeyNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(hideDockPreferenceChanged),
+            name: .hideDockIconPreferenceChanged,
+            object: nil
+        )
+
         setupStatusItem()
+        applyActivationPolicy(forMainWindowVisible: hasVisibleMainWindow())
+    }
+
+    /// Dock icon click when the Dock icon is showing.
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if !flag { openMainWindow() }
+        return true
+    }
+
+    // MARK: - Window identification
+
+    /// A window we would consider "the app's main window".
+    ///
+    /// The `NSStatusBarWindow` backing the menu bar item is visible and is **not** an
+    /// `NSPanel`, so a plain `!($0 is NSPanel)` test matches it. That was the bug: with the
+    /// real window closed, "Open Main Window" would find the status bar window, order it
+    /// front, and return — so nothing appeared to happen.
+    private func isEligibleMainWindow(_ window: NSWindow) -> Bool {
+        if window is NSPanel { return false }
+        if String(describing: type(of: window)).contains("StatusBar") { return false }
+        // SwiftUI's menu bar extra and other helper windows carry no title bar.
+        if !window.styleMask.contains(.titled) { return false }
+        return true
+    }
+
+    private func hasVisibleMainWindow() -> Bool {
+        NSApp.windows.contains { isEligibleMainWindow($0) && $0.isVisible && !$0.isMiniaturized }
+    }
+
+    private func applyActivationPolicy(forMainWindowVisible visible: Bool) {
+        // Only drop to accessory when the user actually asked for agent mode.
+        let policy: NSApplication.ActivationPolicy = (visible || !Self.hideDockIcon) ? .regular : .accessory
+        if NSApp.activationPolicy() != policy {
+            NSApp.setActivationPolicy(policy)
+        }
+    }
+
+    @objc private func hideDockPreferenceChanged() {
+        applyActivationPolicy(forMainWindowVisible: hasVisibleMainWindow())
+        rebuildStatusMenu()
+    }
+
+    @objc private func windowDidBecomeKey(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow, isEligibleMainWindow(window) else { return }
+        if mainWindow !== window {
+            mainWindow = window
+            // Keep the instance alive across close so we can re-show it.
+            window.isReleasedWhenClosed = false
+        }
+        applyActivationPolicy(forMainWindowVisible: true)
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
@@ -46,19 +128,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func windowDidClose(_ notification: Notification) {
-        // When a window closes, check if any visible non-panel windows remain
-        // If not, hide the app from the dock (accessory mode = menu bar only)
+        guard let window = notification.object as? NSWindow, isEligibleMainWindow(window) else { return }
         Task { @MainActor in
-            // Small delay to let the window finish closing
-            try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
-
-            let hasVisibleWindows = NSApp.windows.contains { window in
-                !window.isMiniaturized && window.isVisible && !(window is NSPanel)
-            }
-
-            if !hasVisibleWindows {
-                NSApp.setActivationPolicy(.accessory)
-            }
+            // Let the window finish closing before asking what is still on screen.
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            applyActivationPolicy(forMainWindowVisible: hasVisibleMainWindow())
         }
     }
 
@@ -91,6 +165,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             action: #selector(checkForUpdates),
             keyEquivalent: "u"
         ))
+
+        let dockItem = NSMenuItem(
+            title: "Hide Dock Icon",
+            action: #selector(toggleHideDockIcon),
+            keyEquivalent: ""
+        )
+        dockItem.state = Self.hideDockIcon ? .on : .off
+        statusMenu.addItem(dockItem)
 
         if model.isRunning {
             if model.isPaused {
@@ -151,14 +233,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return image
     }
 
-    @objc private func openMainWindow() {
+    @objc func openMainWindow() {
         NSApp.setActivationPolicy(.regular)
         NSApp.activate(ignoringOtherApps: true)
 
-        if let existing = NSApp.windows.first(where: { !($0 is NSPanel) && $0.isVisible })
-            ?? NSApp.windows.first(where: { !($0 is NSPanel) })
+        // Prefer the window we retained; fall back to any eligible one. Both filters skip
+        // the status bar window, which is neither a panel nor titled.
+        if let existing = mainWindow
+            ?? NSApp.windows.first(where: { isEligibleMainWindow($0) && $0.isVisible })
+            ?? NSApp.windows.first(where: { isEligibleMainWindow($0) })
         {
             existing.makeKeyAndOrderFront(nil)
+            mainWindow = existing
+            existing.isReleasedWhenClosed = false
             return
         }
 
@@ -176,7 +263,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 .environmentObject(model)
                 .environmentObject(scheduler)
         )
+        window.isReleasedWhenClosed = false
         window.makeKeyAndOrderFront(nil)
+        mainWindow = window
+    }
+
+    @objc private func toggleHideDockIcon() {
+        Self.hideDockIcon.toggle()
     }
 
     @objc private func runBackupNow() {

--- a/ImmiBridge/ImmiBridge/UI/Info.plist
+++ b/ImmiBridge/ImmiBridge/UI/Info.plist
@@ -22,10 +22,15 @@
 	<string>12.0</string>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>ImmiBridge uses Photos automation to read keywords (tags) so they can be synced to Immich.</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_http._tcp</string>
+		<string>_https._tcp</string>
+	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2025 Emery Silberman. All rights reserved.</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>ImmiBridge needs local network access to connect to your Immich server.</string>
+	<string>ImmiBridge needs local network access to connect to your Immich server on your home or office network.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>ImmiBridge needs access to export your Photos library for backup.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/ImmiBridge/ImmiBridge/UI/LocalNetworkPermission.swift
+++ b/ImmiBridge/ImmiBridge/UI/LocalNetworkPermission.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Triggers the macOS Local Network privacy prompt.
+///
+/// Originally contributed by @59n in PR #29.
+///
+/// A plain `URLSession` request to a LAN address can fail with "Local network
+/// prohibited" *without* macOS ever showing the permission dialog. When that happens the
+/// app never appears in System Settings → Privacy & Security → Local Network at all, so
+/// telling the user to enable the toggle is useless — there is nothing there to enable.
+///
+/// Browsing a Bonjour service type declared in `NSBonjourServices` is the reliable way to
+/// make TCC present the dialog. We do not care about the results of the browse; running it
+/// at all is the point.
+enum LocalNetworkPermission {
+    private static let lock = NSLock()
+    private static var browser: NetServiceBrowser?
+    private static var delegateBox: BrowserDelegate?
+    private static var stopWorkItem: DispatchWorkItem?
+
+    /// Browse period. Long enough for TCC to present the sheet, short enough that we are
+    /// not holding a browser open behind the user's back.
+    private static let browseDuration: TimeInterval = 3.0
+
+    /// Starts a short Bonjour browse so TCC can show the permission dialog.
+    /// Safe to call repeatedly; an in-flight browse is replaced rather than stacked.
+    static func requestPrompt() {
+        // NetServiceBrowser must be started on the main thread.
+        if Thread.isMainThread {
+            startBrowseOnMain()
+        } else {
+            DispatchQueue.main.async { startBrowseOnMain() }
+        }
+    }
+
+    private static func startBrowseOnMain() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        browser?.stop()
+        stopWorkItem?.cancel()
+        browser = nil
+        delegateBox = nil
+        stopWorkItem = nil
+
+        let newBrowser = NetServiceBrowser()
+        let newDelegate = BrowserDelegate()
+        newBrowser.delegate = newDelegate
+        // Service type must appear in Info.plist -> NSBonjourServices, or the browse is
+        // rejected before TCC is ever consulted.
+        newBrowser.searchForServices(ofType: "_http._tcp.", inDomain: "local.")
+
+        browser = newBrowser
+        delegateBox = newDelegate
+
+        let work = DispatchWorkItem {
+            lock.lock()
+            defer { lock.unlock() }
+            newBrowser.stop()
+            // Only clear if we are still the current browse; a newer one may have replaced us.
+            if browser === newBrowser {
+                browser = nil
+                delegateBox = nil
+            }
+            stopWorkItem = nil
+        }
+        stopWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + browseDuration, execute: work)
+    }
+}
+
+/// `NetServiceBrowser` holds its delegate weakly, so something has to keep this alive for
+/// the duration of the search.
+private final class BrowserDelegate: NSObject, NetServiceBrowserDelegate {
+    func netServiceBrowser(_ browser: NetServiceBrowser, didNotSearch errorDict: [String: NSNumber]) {
+        // Permission denied, or no interface to browse on. Nothing to do: the actual
+        // connection attempt is what surfaces a user-facing error.
+    }
+
+    func netServiceBrowser(_ browser: NetServiceBrowser, didFind service: NetService, moreComing: Bool) {
+        // Results are irrelevant — running the browse is what prompts for permission.
+    }
+
+    func netServiceBrowserDidStopSearch(_ browser: NetServiceBrowser) {}
+}

--- a/ImmiBridge/ImmiBridge/UI/MenuBarView.swift
+++ b/ImmiBridge/ImmiBridge/UI/MenuBarView.swift
@@ -163,38 +163,22 @@ struct MenuBarView: View {
     }
 
     private func openMainWindow() {
-        // Prefer reusing an existing non-panel window (menu bar extra uses a panel).
-        if let existing = NSApp.windows.first(where: { !($0 is NSPanel) && $0.isVisible })
-            ?? NSApp.windows.first(where: { !($0 is NSPanel) })
-        {
-            NSApp.setActivationPolicy(.regular)
-            NSApp.activate(ignoringOtherApps: true)
-            existing.makeKeyAndOrderFront(nil)
+        // Single implementation lives in AppDelegate: it excludes the status bar window
+        // (which is neither a panel nor titled) and retains the real window so reopening
+        // works after a close.
+        if let delegate = NSApp.delegate as? AppDelegate {
+            delegate.openMainWindow()
             return
         }
-
-        // Create a new main window if none exist (only available on macOS 13+).
-        // Post notification to request window opening (handled by WindowOpenerView)
+        // Fallback: ask SwiftUI to create one.
         NotificationCenter.default.post(name: .openMainWindowRequested, object: nil)
-
-        // SwiftUI creates the window asynchronously; bring it to front once it exists.
-        Task { @MainActor in
-            for _ in 0..<20 {
-                if let w = NSApp.windows.first(where: { !($0 is NSPanel) }) {
-                    NSApp.setActivationPolicy(.regular)
-                    NSApp.activate(ignoringOtherApps: true)
-                    w.makeKeyAndOrderFront(nil)
-                    return
-                }
-                try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
-            }
-        }
     }
 }
 
 // Notification name for requesting main window to open
 extension Notification.Name {
     static let openMainWindowRequested = Notification.Name("openMainWindowRequested")
+    static let hideDockIconPreferenceChanged = Notification.Name("hideDockIconPreferenceChanged")
 }
 
 /// Helper view that handles window opening on macOS 13+

--- a/ImmiBridge/ImmiBridge/UI/PhotoBackupViewModel.swift
+++ b/ImmiBridge/ImmiBridge/UI/PhotoBackupViewModel.swift
@@ -1092,10 +1092,27 @@ final class PhotoBackupViewModel: ObservableObject {
         var pingReq = URLRequest(url: apiBase.appendingPathComponent("server/ping"))
         pingReq.setValue(apiKey, forHTTPHeaderField: "x-api-key")
 
+        // URLSession on its own can fail with "Local network prohibited" without macOS
+        // ever presenting the Local Network dialog — and until it is presented once, the
+        // app is absent from System Settings entirely, so the error we show below tells
+        // the user to flip a switch that does not exist. A Bonjour browse is what forces
+        // the prompt. See LocalNetworkPermission.
+        let isLocal = isLocalNetworkURL(immichServerURL)
+        if isLocal {
+            LocalNetworkPermission.requestPrompt()
+            // The sheet is modal to the user, not to us: allow time to actually answer it.
+            pingReq.timeoutInterval = 20
+        }
+
         Task.detached { [weak self] in
             var lastError: Error?
             for attempt in 1...3 {
                 do {
+                    if isLocal, attempt == 1 {
+                        // Let TCC get the sheet on screen before the request starts, so a
+                        // first-run connection test does not fail before it is answered.
+                        try? await Task.sleep(nanoseconds: 800_000_000)
+                    }
                     let (pingData, pingResp) = try await URLSession.shared.data(for: pingReq)
                     guard let http = pingResp as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
                         throw NSError(domain: "immich", code: (pingResp as? HTTPURLResponse)?.statusCode ?? -1)
@@ -1147,8 +1164,10 @@ final class PhotoBackupViewModel: ObservableObject {
                     if attempt < 3 {
                         await MainActor.run { [weak self] in
                             self?.immichTestStatus = "Testing… (\(attempt + 1)/3)"
+                            // Re-arm the browse so a dismissed sheet can come back.
+                            if isLocal { LocalNetworkPermission.requestPrompt() }
                         }
-                        try? await Task.sleep(nanoseconds: 600_000_000) // 0.6s
+                        try? await Task.sleep(nanoseconds: isLocal ? 1_200_000_000 : 600_000_000)
                         continue
                     }
                 }
@@ -1175,7 +1194,9 @@ final class PhotoBackupViewModel: ObservableObject {
 
                         This may be because ImmiBridge needs permission to access your local network.
 
-                        Please go to System Settings → Privacy & Security → Local Network and enable access for ImmiBridge, then try again.
+                        Open System Settings → Privacy & Security → Local Network and enable access for ImmiBridge, then try again.
+
+                        If ImmiBridge is not listed there at all, quit and reopen the app and test the connection again — macOS only adds an app to that list once it has asked for access.
 
                         Error: \(errorText)
                         """


### PR DESCRIPTION
Ports the two parts of #29 that were nothing to do with the Immich v2/v3 question. Original work by @59n — #30 superseded that PR for the API changes and dropped these along with it, which wasn't right. They stand on their own and neither depends on which Immich version you run.

## Local Network permission

A `URLSession` request to a LAN address can fail with "Local network prohibited" **without macOS ever showing the permission dialog**. And until that dialog has been shown once, the app isn't listed in System Settings → Privacy & Security → Local Network at all.

That matters because ImmiBridge already detects this error and tells the user to go enable the toggle — pointing them at a row that doesn't exist yet. Frustrating in exactly the way that makes someone give up on an app.

Browsing a Bonjour service type declared in `NSBonjourServices` is the reliable way to force the prompt. This adds:

- `LocalNetworkPermission` — a short, coalesced `_http._tcp` browse, safe to call repeatedly and from any thread
- `NSBonjourServices` in Info.plist, **without which the browse is rejected before TCC is ever consulted** (the app had `NSLocalNetworkUsageDescription` but not this)
- a hook in the connection test that runs the browse first, allows time to answer the sheet, and re-arms between retries
- the "not listed at all" case spelled out in the error text

## Menu-bar agent mode

This one fixes a real bug in what's currently shipped: **"Open Main Window" could do nothing at all.**

```swift
NSApp.windows.first(where: { !($0 is NSPanel) && $0.isVisible })
```

`NSStatusBarWindow` is visible, and it is not an `NSPanel`. So once the main window is closed, this selects the status bar window itself, calls `makeKeyAndOrderFront` on it, and returns. The user clicks the menu item and nothing happens.

Verified with a harness that reproduces the exact window set:

```
windows present:
  NSStatusBarWindow  visible=true titled=false
OLD predicate picks: NSStatusBarWindow      <- the bug
NEW predicate picks: nil                    <- falls through to showing the real window
```

Changes:

- `isEligibleMainWindow` excludes panels, the status bar window, and untitled helper windows
- the main window is retained with `isReleasedWhenClosed = false`, so reopening re-shows *that instance* rather than building a replacement (SwiftUI releases `WindowGroup` windows on close, which is why it fell through before)
- `MenuBarView` had a second, divergent copy of this logic with the same bug — it now routes through `AppDelegate`, so there's one implementation
- "Hide Dock Icon" toggle in the status menu
- `applicationShouldHandleReopen` so clicking the Dock icon reopens the window

## One deliberate deviation from #29

`hideDockIcon` defaults to **`false`**, not `true`. Defaulting it on would make the Dock icon silently vanish for every existing user the moment they updated.

## Testing

- Builds clean, no new warnings
- Window-selection bug reproduced and the fix confirmed against it
- Bonjour browse verified to start, coalesce overlapping calls, run off the main thread, and tear down without crashing or hanging; `_http._tcp` browsing confirmed working on the test machine
- App launches, runs and quits cleanly; no crash reports

**Not verified:** the TCC dialog actually appearing. That fires once per app per machine and depends on existing permission state, so testing it properly needs a machine that hasn't already answered it. The mechanism, the entitlements (`app-sandbox` + `network.client`) and the plist key are all confirmed correct, but I can't claim to have watched the sheet appear.
